### PR TITLE
[FIXED JENKINS-8298] & [FEATURE JENKINS-8296]

### DIFF
--- a/src/main/java/hudson/plugins/persona/QuotePublisher.java
+++ b/src/main/java/hudson/plugins/persona/QuotePublisher.java
@@ -64,8 +64,13 @@ public class QuotePublisher extends Notifier {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        if (persona !=null)
-            build.getActions().add(persona.generateQuote(build));
+        if (persona !=null) {
+        	if (persona instanceof RandomPersona) {
+        		((RandomPersona) persona).resetCurrentPersona();
+        	}
+        	
+			build.getActions().add(persona.generateQuote(build));
+		}
         return true;
     }
 

--- a/src/main/java/hudson/plugins/persona/RandomPersona.java
+++ b/src/main/java/hudson/plugins/persona/RandomPersona.java
@@ -1,0 +1,168 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010-2011, InfraDNA, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.persona;
+
+import hudson.ExtensionList;
+import hudson.model.AbstractBuild;
+import hudson.model.Hudson;
+import hudson.plugins.persona.simple.Image;
+import hudson.plugins.persona.simple.SimplePersona;
+import hudson.plugins.persona.xml.XmlBasedPersona;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Random persona implementation on top of SimplePersona
+ * 
+ * @author whren
+ *
+ */
+public class RandomPersona extends SimplePersona {
+	/**
+	 * Random persona display name
+	 */
+	public static final String RANDOM_PERSONA_DISPLAYNAME = "Random Persona";
+	
+	/**
+	 * Random persona id
+	 */
+	public static final String RANDOM_PERSONA_ID = "RandomPersonaId";
+	
+	/**
+	 * Persona Randomizer
+	 */
+    private static final Random random = new Random();
+    
+    private Map<AbstractBuild<?, ?>, XmlBasedPersona> mapPersonas =
+    	new HashMap<AbstractBuild<?, ?>, XmlBasedPersona>();
+    
+    private XmlBasedPersona currentPersona;
+    
+    /**
+     * Creates a RandomPersona
+     * 
+     * @return
+     * 		A newly created RandomPersona
+     */
+    public static RandomPersona create() {
+    	return new RandomPersona();
+    }
+    
+	/**
+	 * Default constructor
+	 */
+	private RandomPersona() {
+		super(RANDOM_PERSONA_ID, null, null, null, null);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Image getDefaultImage() {
+		return getCurrentPersona().getDefaultImage();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Image getImage(AbstractBuild<?, ?> build) {
+		return getCurrentPersona().getImage(build);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getDisplayName() {
+		return RANDOM_PERSONA_DISPLAYNAME;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+    public synchronized String getRandomQuoteText(AbstractBuild<?, ?> build) {
+		return getCurrentPersona().getDisplayName()
+			+ " - "
+			+ getCurrentPersona().getRandomQuoteText(build);
+    }
+	
+	/**
+	 * Returns the build associated persona
+	 * 
+	 * @param build
+	 * 			the build from wich to retrieve the associated persona
+	 * @return
+	 * 			persona associated to the build
+	 */
+	public XmlBasedPersona getPersona(AbstractBuild<?,?> build) {
+		return mapPersonas.get(build);
+	}
+	
+	/**
+	 * Return the current persona, generate one if non existent
+	 * 
+	 * @return
+	 * 			The current persona
+	 */
+	public XmlBasedPersona getCurrentPersona() {
+		if (null == currentPersona) {
+			currentPersona = resetCurrentPersona();
+		}
+		
+		return currentPersona;
+	}
+	
+	/**
+	 * Reset the current persona and return a new one
+	 * 
+	 * @return
+	 * 			The new current persona
+	 */
+	public XmlBasedPersona resetCurrentPersona() {
+		currentPersona = randomPersona();
+		return currentPersona;
+	}
+	
+    /**
+     * Returns a random persona form all personas
+     * 
+     * @return
+     * 		A random persona
+     */
+    public static XmlBasedPersona randomPersona() {
+    	ExtensionList<XmlBasedPersona> personas = allXmlBased();
+    	return personas.get(random.nextInt(personas.size()));
+    }
+    
+    /**
+     * Returns all the registered {@link XmlBasedPersona}s.
+     */
+    public static ExtensionList<XmlBasedPersona> allXmlBased() {
+        return Hudson.getInstance().getExtensionList(XmlBasedPersona.class);
+    }
+}

--- a/src/main/java/hudson/plugins/persona/RandomPersonaFinder.java
+++ b/src/main/java/hudson/plugins/persona/RandomPersonaFinder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010, InfraDNA, Inc.
+ * Copyright (c) 2010-2011, InfraDNA, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,28 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package hudson.plugins.persona.simple;
+package hudson.plugins.persona;
 
-import hudson.model.InvisibleAction;
-import hudson.plugins.persona.Quote;
-import hudson.plugins.persona.RandomPersona;
+import hudson.Extension;
+import hudson.ExtensionComponent;
+import hudson.ExtensionFinder;
+import hudson.model.Hudson;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * Default implementation of quote that renders a simple non-localized text.
+ * @author whren
  *
- * @author Kohsuke Kawaguchi
  */
-public abstract class AbstractQuoteImpl extends InvisibleAction implements Quote {
-    public final SimplePersona persona;
+@Extension
+public class RandomPersonaFinder extends ExtensionFinder {
+    @Override
+    public <T> Collection<ExtensionComponent<T>> find(Class<T> type, Hudson hudson) {
+        if (type != Persona.class) {
+			return Collections.emptyList();
+		}
 
-    public AbstractQuoteImpl(SimplePersona persona) {
-    	if (persona instanceof RandomPersona) {
-    		this.persona = ((RandomPersona) persona).getCurrentPersona();
-    	} else {
-    		this.persona = persona;
-    	}
+        List<ExtensionComponent<RandomPersona>> r = new ArrayList<ExtensionComponent<RandomPersona>>();
+
+        parsePersonaInto(r);
+        
+        return (List)r;
     }
 
-    public abstract String getQuote();
-    public abstract Image getImage();
+    private void parsePersonaInto(Collection<ExtensionComponent<RandomPersona>> result) {
+    	result.add(new ExtensionComponent<RandomPersona>(RandomPersona.create()));
+    }
 }

--- a/src/main/java/hudson/plugins/persona/xml/XmlPersonaFinder.java
+++ b/src/main/java/hudson/plugins/persona/xml/XmlPersonaFinder.java
@@ -51,7 +51,9 @@ import java.util.logging.Logger;
 public class XmlPersonaFinder extends ExtensionFinder {
     @Override
     public <T> Collection<ExtensionComponent<T>> find(Class<T> type, Hudson hudson) {
-        if (type!=Persona.class)    return Collections.emptyList();
+        if ((type!=Persona.class) && (type != XmlBasedPersona.class)) {
+			return Collections.emptyList();
+		}
 
         List<ExtensionComponent<XmlBasedPersona>> r = new ArrayList<ExtensionComponent<XmlBasedPersona>>();
 

--- a/src/main/java/hudson/plugins/persona/xml/XmlPersonaReloader.java
+++ b/src/main/java/hudson/plugins/persona/xml/XmlPersonaReloader.java
@@ -7,6 +7,7 @@ import hudson.Util;
 import hudson.model.Hudson;
 import hudson.model.RootAction;
 import hudson.plugins.persona.Persona;
+import org.dom4j.DocumentException;
 import org.kohsuke.stapler.StaplerResponse;
 
 import java.io.IOException;
@@ -39,7 +40,12 @@ public class XmlPersonaReloader implements RootAction {
         ExtensionList<Persona> all = Persona.all();
 
         for (XmlBasedPersona p : Util.filter(all,XmlBasedPersona.class)) {
-            w.println("Reloaded "+p.xml);
+			try {
+				p.reload();
+				w.println("Reloaded "+p.xml);
+			} catch (DocumentException de) {
+				w.println("Error on reloading " + p.xml);
+			}
         }
 
         // find new personas


### PR DESCRIPTION
Commit #1

[FIXED JENKINS-8298] Reloading persona does not reloads existing persona quotes

When using the reload persona url, it does not reload personas quotes. It only loads potentialy new personas.
Looks like a Persona.reload() is missing in hudson.plugins.persona.xml.XmlPersonaReloader.doIndex(StaplerResponse rsp).

Commit #2

[FEATURE JENKINS-8296] Allow use of random persona instead of a fix one 

It would be great to allow per project use of a random persona at each launch of a build.

How :

In the configuration of a project, the "Random Persona" will be choose in the list of available personas.

At each launch of a build the plugin will verify if the choosen persona is the "Random Persona", if so this "Random Persona" will randomize the choose of one of the personas configured.

The remaining process will be the same as today.
The project quote and icon will of course reflect the last build.
